### PR TITLE
Don't just concat new results with old; use keyname to compare.

### DIFF
--- a/bifrost.js
+++ b/bifrost.js
@@ -242,6 +242,17 @@ var Bifrost = (function(global){
                             keyname = self._keyname,
                             timestamp = self._timestamp;
 
+                        // The algorithm works like this:
+                        // Look up the data by the keyname. If it is not present
+                        // in the store, add it. If it is, generate a list of
+                        // mutations needed to make the old item match the new
+                        // item. Finally, apply those changes, mutating the
+                        // object in-place.
+
+                        // An alternative method, and one that sits a little
+                        // easier with me, would be to make the state immutable,
+                        // and simply throw it out, replacing it with a new
+                        // value.
                         for (var i=0;i<items.length;i++) {
                             var itemKey = items[i][keyname],
                                 newItem = items[i],


### PR DESCRIPTION
Multiple calls to sync were appending the results of the new request onto the existing state... in order to hack around this I added a really naive comparison between elements.

Also, I had to add a `_getResults` option to specify how to get data from the HTTP response.
